### PR TITLE
fix circular dependencies (ref #2)

### DIFF
--- a/crates/shenzi/src/graph.rs
+++ b/crates/shenzi/src/graph.rs
@@ -1,7 +1,12 @@
-use std::{collections::HashMap, fmt::Display, path::{Path, PathBuf}};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result, anyhow};
 use bimap::BiHashMap;
+use log::info;
 use petgraph::{Direction::Incoming, Graph, algo::toposort, graph::NodeIndex, visit::EdgeRef};
 
 use crate::{factory::Factory, node::Node, paths::normalize_path};
@@ -51,9 +56,17 @@ impl<T: Factory> FileGraph<T> {
         self.inner.node_count()
     }
 
-
     pub fn contains_path(&self, p: &Path) -> bool {
         self.path_by_node.contains_key(p)
+    }
+
+    pub fn remove_node(&mut self, idx: NodeIndex) {
+        self.inner.remove_node(idx);
+        match self.idx_by_path.get_by_left(&idx) {
+            Some(path) => self.path_by_node.remove(path),
+            None => None,
+        };
+        self.idx_by_path.remove_by_left(&idx);
     }
 
     /// simply add a node to the graph, this is a plain operation
@@ -103,24 +116,20 @@ impl<T: Factory> FileGraph<T> {
         let mut search_paths = search_paths.clone();
         search_paths.extend(extra_search_paths);
 
-        let mut all_parent_idx = Vec::new();
-        for p in deps {
-            let p = normalize_path(&p);
-            if let Some(parent_idx) = self.idx_by_path.get_by_right(&p) {
-                all_parent_idx.push(*parent_idx);
-                continue;
-            }
-            let parent_node = self.factory.make(&p, known_libs, &search_paths)?;
-            if let Some(parent_node) = parent_node {
-                // info!("adding node recursively in graph, path={}", p.display());
-                let parent_idx = self
-                    .add_tree(parent_node, known_libs, false, &search_paths)
-                    .context(anyhow!("file: {}", p.display()))?;
-                all_parent_idx.push(parent_idx);
-            }
-        }
-
+        // first insert the node, prevent infinite recursion in case of circular dependency
+        let our_path = node.path.clone();
         let idx = self.add_node(node, replace);
+
+        let all_parent_idx = match self.add_parents(&deps, known_libs, &search_paths) {
+            Ok(all_parent_idx) => all_parent_idx,
+            Err(e) => {
+                // on error, remove ourselves
+                // next time, someone might succeed when they add to tree
+                self.remove_node(idx);
+                return Err(e).context(anyhow!("node: {}", our_path.display()));
+            }
+        };
+
         for parent_idx in all_parent_idx {
             self.inner.add_edge(parent_idx, idx, ());
             if !self.inner.contains_edge(parent_idx, idx) {
@@ -130,6 +139,30 @@ impl<T: Factory> FileGraph<T> {
         Ok(idx)
     }
 
+    fn add_parents(
+        &mut self,
+        deps: &Vec<PathBuf>,
+        known_libs: &HashMap<String, PathBuf>,
+        search_paths: &Vec<PathBuf>,
+    ) -> Result<Vec<NodeIndex>> {
+        let mut all_parent_idx = Vec::new();
+        for p in deps {
+            let p = normalize_path(&p);
+            if let Some(parent_idx) = self.idx_by_path.get_by_right(&p) {
+                all_parent_idx.push(*parent_idx);
+                continue;
+            }
+            let parent_node = self.factory.make(&p, known_libs, &search_paths)?;
+            if let Some(parent_node) = parent_node {
+                info!("add node recursive, path={}", p.display());
+                let parent_idx = self
+                    .add_tree(parent_node, known_libs, false, &search_paths)
+                    .context(anyhow!("file: {}", p.display()))?;
+                all_parent_idx.push(parent_idx);
+            }
+        }
+        Ok(all_parent_idx)
+    }
 
     pub fn get_node_by_path(&self, path: &PathBuf) -> Option<&Node> {
         self.path_by_node.get(path)
@@ -305,7 +338,6 @@ mod test {
         println!("*************start complex test**********************");
         let tmp = create_temp_dir();
 
-
         let dep2_path = touch_path(&tmp, "dep2.py");
         let dep2 = Node::mock(dep2_path.clone(), vec![]).unwrap();
 
@@ -316,7 +348,11 @@ mod test {
         let dep3 = Node::mock(dep3_path.clone(), vec![dep2_path.clone()]).unwrap();
 
         let main_path = touch_path(&tmp, "python");
-        let main = Node::mock(main_path.clone(), vec![dep1_path.clone(), dep3_path.clone()]).unwrap();
+        let main = Node::mock(
+            main_path.clone(),
+            vec![dep1_path.clone(), dep3_path.clone()],
+        )
+        .unwrap();
 
         let path_by_deps = HashMap::from([
             (main_path, vec![dep1_path.clone(), dep3_path.clone()]),

--- a/crates/shenzi/src/pkg/mod.rs
+++ b/crates/shenzi/src/pkg/mod.rs
@@ -7,10 +7,15 @@ use log::info;
 use pathdiff::diff_paths;
 
 use crate::{
-    external::download_patchelf, gather::NodeFactory, graph::FileGraph, node::Node, pkg::{
-        export::{mk_parent_dirs, Export},
+    external::download_patchelf,
+    gather::NodeFactory,
+    graph::FileGraph,
+    node::Node,
+    pkg::{
+        export::{Export, mk_parent_dirs},
         paths::ExportedFileTree,
-    }, warnings::Warning
+    },
+    warnings::Warning,
 };
 
 pub use patch::LibPatch;
@@ -27,29 +32,20 @@ pub fn move_all_nodes(
 ) -> Result<PathBuf> {
     info!("exporting files to dist");
     download_patchelf().context("error in downloading patchelf")?;
-    let total = graph.len();
-    let mut i = 0;
-    // TODO: parallelize this (we need custom toposort implementation)
-    let mut main_destination = None;
-    for node in graph
-        .toposort()
-        .context("failed in running toposort on the dependency graph")?
-    {
-        if node.path == *main_script_path {
-            main_destination = node.pkg.destination(&node.path, dist);
-        }
-        let deps = graph.get_node_dependencies(&node);
-        move_to_dist(&node, &deps, dist).unwrap();
-        i += 1;
-        if total / 10 != 0 && i % (total / 10) == 0 {
-            info!("exported {}/{} files", i, total);
-        }
-    }
 
-    main_destination.ok_or(anyhow!(
-        "could not find the final path for main script, script={}",
-        main_script_path.display()
-    ))
+    // TODO: parallelize each step
+    let nodes: Vec<&Node> = graph.iter_nodes().collect();
+    move_reals(&nodes, dist)?;
+    mk_symlink_farms(&nodes, graph, dist)?;
+    cp_to_destinations(&nodes, dist)?;
+
+    graph
+        .get_node_by_path(main_script_path)
+        .map(|n| n.path.clone())
+        .ok_or(anyhow!(
+            "could not find the final path for main script, script={}",
+            main_script_path.display()
+        ))
 }
 
 pub fn write_warnings(warnings: Vec<Warning>, dist: &PathBuf) -> Result<(PathBuf, bool)> {
@@ -67,79 +63,114 @@ pub fn write_warnings(warnings: Vec<Warning>, dist: &PathBuf) -> Result<(PathBuf
     }
 }
 
-pub fn move_to_dist(node: &Node, deps: &Vec<Node>, dist: &PathBuf) -> Result<()> {
-    // todo: python executable does not have a symlink farm, fix that
-    // for that we need to also remove the hardcoding we have done for patching
-    // deps are already exported, now we export node
-    let real_path = mk_reals(node, dist).with_context(|| {
-        format!(
-            "could not create reals directory for path={} dist={}",
-            node.path.display(),
-            dist.display()
-        )
-    })?;
-
-    let symlink_farm = mk_symlink_farm(node, deps, dist).with_context(|| {
-        format!(
-            "could not create symlink farm for path={} dist={}",
-            node.path.display(),
-            dist.display()
-        )
-    })?;
-
-    // todo: chain from mk_symlink_farm directly, it should return the path like reals
-    symlink_farm
-        .as_ref()
-        .map(|p| -> Result<()> {
-            match real_path {
-                Some(ref real_path) => node.deps.patch(real_path, &p).with_context(|| {
-                    anyhow!(
-                        "failed in patching shared library at node_path={} real_path={} symlink_farm={}",
-                        node.path.display(),
-                        real_path.display(),
-                        p.display()
-                    )
-                }),
-                None => Ok(()),
-            }
-        })
-        .transpose()
-        .with_context(|| {
-            anyhow!(
-                "failed in patching library for node, path={}",
-                node.path.display()
-            )
-        })?;
-
-    let path_to_cp_to_destination = real_path.as_ref().unwrap_or(&node.path);
-    let destination = node.pkg.destination(&node.path, dist);
-    destination
-        .as_ref()
-        .map(|dest| {
-            node.pkg
-                .to_destination(&path_to_cp_to_destination, &dest, &dist)
-        })
-        .transpose()
-        .with_context(|| {
+pub fn move_reals(nodes: &Vec<&Node>, dist: &PathBuf) -> Result<()> {
+    info!("Step: copy assets to dist/reals");
+    let total = nodes.len();
+    let mut i = 0;
+    for node in nodes {
+        mk_reals(node, dist).with_context(|| {
             format!(
-                "could not move to destination for path={} dist={}",
+                "could not create reals directory for path={} dist={}",
                 node.path.display(),
                 dist.display()
             )
         })?;
-
-    if let (Some(dest_path), Some(symlink_farm_path), Some(real_path)) = (
-        destination.as_ref(),
-        symlink_farm.as_ref(),
-        real_path.as_ref(),
-    ) {
-        // hack: this is very bad
-        // need better code for this
-        node.deps.patch_for_destination(dest_path, real_path, symlink_farm_path).with_context(|| {
-            anyhow!("failure in patching destination for destination={} real_path={} symlink_farm={}", dest_path.display(), real_path.display(), symlink_farm_path.display())
-        })?;
+        i += 1;
+        if total / 10 != 0 && i % (total / 10) == 0 {
+            info!("\tprogress: {}/{} files", i, total);
+        }
     }
+    Ok(())
+}
 
+pub fn mk_symlink_farms(
+    nodes: &Vec<&Node>,
+    g: &FileGraph<NodeFactory>,
+    dist: &PathBuf,
+) -> Result<()> {
+    info!("Step: make symlink farms");
+    let total = nodes.len();
+    let mut i = 0;
+    for node in nodes {
+        let deps = g.get_node_dependencies(node);
+        let symlink_farm = mk_symlink_farm(node, &deps, dist).with_context(|| {
+            format!(
+                "could not create symlink farm for path={} dist={}",
+                node.path.display(),
+                dist.display()
+            )
+        })?;
+        let real_path = node.pkg.reals(&node, dist);
+        symlink_farm
+            .as_ref()
+            .map(|p| -> Result<()> {
+                match real_path {
+                    Some(ref real_path) => node.deps.patch(real_path, &p).with_context(|| {
+                        anyhow!(
+                            "failed in patching shared library at node_path={} real_path={} symlink_farm={}",
+                            node.path.display(),
+                            real_path.display(),
+                            p.display()
+                        )
+                    }),
+                    None => Ok(()),
+                }
+            })
+            .transpose()
+            .with_context(|| {
+                anyhow!(
+                    "failed in patching library for node, path={}",
+                    node.path.display()
+                )
+            })?;
+        i += 1;
+        if total / 10 != 0 && i % (total / 10) == 0 {
+            info!("\tprogress: {}/{} files", i, total);
+        }
+    }
+    Ok(())
+}
+
+pub fn cp_to_destinations(nodes: &Vec<&Node>, dist: &PathBuf) -> Result<()> {
+    info!("Step: copy/move/symlink to destination (site-packages)");
+    let total = nodes.len();
+    let mut i = 0;
+    for node in nodes {
+        let real_path = node.pkg.reals(&node, dist);
+        let symlink_farm = node.pkg.symlink_farm(&node.path, dist);
+        let path_to_cp_to_destination = real_path.as_ref().unwrap_or(&node.path);
+        let destination = node.pkg.destination(&node.path, dist);
+        destination
+            .as_ref()
+            .map(|dest| {
+                node.pkg
+                    .to_destination(&path_to_cp_to_destination, &dest, &dist)
+            })
+            .transpose()
+            .with_context(|| {
+                format!(
+                    "could not move to destination for path={} dist={}",
+                    node.path.display(),
+                    dist.display()
+                )
+            })?;
+
+        if let (Some(dest_path), Some(symlink_farm_path), Some(real_path)) = (
+            destination.as_ref(),
+            symlink_farm.as_ref(),
+            real_path.as_ref(),
+        ) {
+            // hack: this is very bad
+            // need better code for this
+            node.deps.patch_for_destination(dest_path, real_path, symlink_farm_path).with_context(|| {
+                anyhow!("failure in patching destination for destination={} real_path={} symlink_farm={}", dest_path.display(), real_path.display(), symlink_farm_path.display())
+            })?;
+        }
+        i += 1;
+        if total / 10 != 0 && i % (total / 10) == 0 {
+            info!("\tprogress: {}/{} files", i, total);
+        }
+    }
     Ok(())
 }
 

--- a/crates/shenzi/src/pkg/patch/elf.rs
+++ b/crates/shenzi/src/pkg/patch/elf.rs
@@ -66,20 +66,24 @@ fn rm_rpath(path: &PathBuf) -> Result<()> {
 }
 
 fn add_rpath(rpath: &str, path: &PathBuf) -> Result<()> {
-    let status = Command::new(patchelf()?)
+    let output = Command::new(patchelf()?)
         .stderr(Stdio::null())
         .arg("--add-rpath")
         .arg(rpath)
         .arg(path)
-        .status()?;
-    if status.success() {
+        .output()?;
+    if output.status.success() {
         Ok(())
     } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "failed in running patchelf to set rpath path={} rpath={} status={:?}",
+            "failed in running patchelf to set rpath path={} rpath={} status={:?}\n\tstdout={}\n\tstderr={}",
             path.display(),
             rpath,
-            status
+            output.status,
+            stdout,
+            stderr,
         )
     }
 }
@@ -130,23 +134,27 @@ fn modify_all_dt_needed(
 }
 
 fn modify_dt_needed(old: &str, new: &str, path: &PathBuf) -> Result<()> {
-    let status = Command::new(patchelf()?)
+    let output = Command::new(patchelf()?)
         .stderr(Stdio::null())
         .arg("--replace-needed")
         .arg(old)
         .arg(new)
         .arg(path)
-        .status()?;
+        .output()?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "failed in running patchelf to modifying DT_NEEDED path={} old={} new={} status={:?}",
+            "failed in running patchelf to modifying DT_NEEDED path={} old={} new={} status={:?}\n\tstdout={}\n\tstderr={}",
             old,
             new,
             path.display(),
-            status
+            output.status,
+            stdout,
+            stderr,
         )
     }
 }

--- a/crates/shenzi/src/pkg/patch/macho.rs
+++ b/crates/shenzi/src/pkg/patch/macho.rs
@@ -61,7 +61,6 @@ fn modify_load_cmds(reals_path: &PathBuf, symlink_farm_path: &PathBuf, mach: &Ma
             );
         }
         modify_load_command(&load_cmd, &dylib_id(&lib_name), reals_path)?;
-        sign_dylib(reals_path)?;
     }
     Ok(())
 }
@@ -95,103 +94,119 @@ fn get_new_rpath(real_path: &PathBuf, symlink_farm: &PathBuf) -> Result<String> 
 }
 
 fn rm_rpath(rpath: &str, path: &PathBuf) -> Result<()> {
-    let status = Command::new("install_name_tool")
-        .stderr(Stdio::null())
+    let output = Command::new("install_name_tool")
         .arg("-delete_rpath")
         .arg(rpath)
         .arg(path)
-        .status()?;
+        .output()?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "failed in running install_name_tool to delete rpath path={} rpath={} status={:?}",
+            "failed in running install_name_tool to delete rpath path={} rpath={} status={:?}\n\tstdout={}\n\tstderr={}",
             rpath,
             path.display(),
-            status
+            output.status,
+            stdout,
+            stderr,
         )
     }
 }
 
 fn add_rpath(rpath: &str, path: &PathBuf) -> Result<()> {
-    let status = Command::new("install_name_tool")
-        .stderr(Stdio::null())
+    let output = Command::new("install_name_tool")
         .arg("-add_rpath")
         .arg(rpath)
         .arg(path)
-        .status()?;
+        .output()?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "failed in running install_name_tool to add rpath path={} rpath={} status={:?}",
+            "failed in running install_name_tool to add rpath path={} rpath={} status={:?}\n\tstdout={}\n\tstderr={}",
             path.display(),
             rpath,
-            status
+            output.status,
+            stdout,
+            stderr,
         )
     }
 }
 
 fn modify_load_command(old: &str, new: &str, path: &PathBuf) -> Result<()> {
-    let status = Command::new("install_name_tool")
-        .stderr(Stdio::null())
+    let output = Command::new("install_name_tool")
         .arg("-change")
         .arg(old)
         .arg(new)
         .arg(path)
-        .status()?;
+        .output()?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "failed in running install_name_tool to modifying load command path={} old={} new={} status={:?}",
+            "failed in running install_name_tool to modifying load command path={} old={} new={} status={:?}\n\tstdout={}\n\tstderr={}",
             old,
             new,
             path.display(),
-            status
+            output.status,
+            stdout,
+            stderr,
         )
     }
 }
 
 fn set_dylib_id(id: String, path: &PathBuf) -> Result<()> {
-    let status = Command::new("install_name_tool")
-        .stderr(Stdio::null())
+    let output = Command::new("install_name_tool")
         .arg("-id")
         .arg(&id)
         .arg(path)
-        .status()?;
+        .output()?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "failed in running install_name_tool to set dylib_id path={} id={} status={:?}",
+            "failed in running install_name_tool to set dylib_id path={} id={} status={:?}\n\tstdout={}\n\tstderr={}",
             id,
             path.display(),
-            status
+            output.status,
+            stdout,
+            stderr,
         )
     }
 }
 
 fn sign_dylib(path: &PathBuf) -> Result<()> {
-    let status = Command::new("codesign")
+    let output = Command::new("codesign")
         .stderr(Stdio::null())
         .arg("-s")
         .arg("-")
         .arg("-f")
         .arg(&path)
-        .status()?;
+        .output()?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "failed in running signing dylib_id path={} status={:?}",
+            "failed in running signing dylib_id path={} status={:?}\n\tstdout={}\n\tstderr={}",
             path.display(),
-            status
+            output.status,
+            stdout,
+            stderr,
         )
     }
 }

--- a/crates/shenzi/src/pkg/patch/mod.rs
+++ b/crates/shenzi/src/pkg/patch/mod.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use log::info;
 
 use crate::pkg::patch::elf::{patch_elf, patch_elf_for_destination};
 use crate::{node::deps::Deps, parse::Binary, pkg::patch::macho::patch_macho};

--- a/python/shenzi/pyproject.toml
+++ b/python/shenzi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shenzi"
-version = "0.0.3"
+version = "0.0.4"
 description = "A greedy Python standalone application bundler"
 readme = "./README.md"
 authors = [


### PR DESCRIPTION
- libraries can have circular dependencies
  - we first insert the node in add_tree
  - I used to do this before, but we don't want add the node to the graph if any of its dependencies fail
    - this is because add_tree might be called again on this node from some other path (nested RPATH search in linux)
      - as an example, libA.so might fail in its dependency resolution, RPATH=empty
      - libC.so depends on libA.so, has RPATH=$ORIGIN/libs
        - ld.so uses this RPATH from libC.so and finds dependency of libA.so
    - we want graph to retry current node if any of the parents fail in resolution
    - so we remove in case of any downstream failures
- toposort wont work as graph is circular now
  - we need nodes to come in order to create symlink farm (dependency should exist in reals directory)
  - we just do each step for all nodes one by one
   - create all reals for all nodes
   - now symlink farm succeeds as all nodes are already in reals
- multiple copies of libraries at different paths will have the same destination in reals, keep track of duplicates and dont put them in